### PR TITLE
Update required tarantool package version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 install:
   - curl -L https://tarantool.io/installer.sh | VER=2.3 sudo -E bash
   - pip install -r requirements.txt
-  - pip install git+https://github.com/tarantool/tarantool-python@master
 
 script:
   - cd django_app && python3 manage.py test && cd ..

--- a/README.md
+++ b/README.md
@@ -4,42 +4,32 @@
 ## Installation
 
 
-Install Tarantool v2 or later. See the installation manual
-for your OS [here](https://www.tarantool.io/en/download/)
+Install Tarantool v2.2+. See the installation manual for your OS [here](https://www.tarantool.io/en/download/)
 
 Make a database directory and run Tarantool instance there:
 
-```shell script
+```bash
 $ mkdir ~/project_db
 $ cd ~/project_db
 $ tarantool
 ```
 
-You will see the Tarantool interpreter. Initialize DB 
-configuration and create password for *admin*
+You will see the Tarantool interpreter. Initialize DB configuration and create password for *admin*
 
-```
-tarantool> box.cfg{listen = 3301}
-tarantool> box.schema.user.passwd('admin', 'password')
-```
-
-Install tarantool-python with dbapi2 on board.  
-Now it is hosted at https://github.com/tarantool/tarantool-python/tree/master  
-**Note:** The PIP *tarantool* package will be updated soon, you'll be able
-to install it with *dbapi2* module by `pip install tarantool` when 
-`tarantool>0.6.6` is released.
-
-```
-pip install git+https://github.com/tarantool/tarantool-python@master#egg=tarantool 
+```lua
+tarantool > box.cfg { listen = 3301 }
+tarantool > box.schema.user.passwd('admin', 'password')
 ```
 
-To set up django-tarantool enter in the command line: 
-```
+To get started with django-tarantool, run the following in a virtual environment:
+
+```bash
 pip install django-tarantool
 ```
 
 Add ``DATABASES`` config of your Tarantool into ``settings.py``
-```
+
+```python
 DATABASES = {
     'default': {
         'ENGINE': 'django_tarantool.backend',
@@ -52,13 +42,18 @@ DATABASES = {
 }
 ```
 
-Mind using *CONN_MAX_AGE* param as very important. 
-It allows to keep connection opened for the specified time in seconds. 
-Otherwise, Django will open the connection to the Tarantool instance on each request
-and close after it, which increases the request latency.
+Mind using *CONN_MAX_AGE* param as very important. It allows to keep connection opened for the specified time in
+seconds. Otherwise, Django will open the connection to the Tarantool instance on each request and close after it, which
+increases the request latency.
 
-Run `migrate` as usual:  
-`python manage.py migrate`
+Run `migrate` as usual:
 
-Run Django develepment server:  
-`python manage.py runserver 0:8000`
+```bash
+python manage.py migrate
+```
+
+Run Django development server:
+
+```bash
+python manage.py runserver 0:8000
+```

--- a/django_app/settings.py
+++ b/django_app/settings.py
@@ -68,6 +68,7 @@ DB_T = {
         'PORT': '3301',
         'USER': 'admin',
         'PASSWORD': 'password',
+        'CONN_MAX_AGE': 3600,
     }
 }
 
@@ -85,6 +86,7 @@ DB_P = {
         'USER': 'postgres',
         'PASSWORD': 'parol',
         'HOST': 'localhost',
+        'CONN_MAX_AGE': 3600,
     }
 }
 

--- a/django_tarantool/backend/operations.py
+++ b/django_tarantool/backend/operations.py
@@ -86,5 +86,5 @@ class DatabaseOperations(BaseDatabaseOperations):
     def no_limit_value(self):
         return 131072
 
-    def sql_flush(self, style, tables, sequences, allow_cascade=False):
+    def sql_flush(self, style, tables, *args, **kwargs):
         return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=3.0.0,<3.1
+tarantool>=0.7.1
 msgpack-python==0.5.6
 model-bakery==1.1.0
 psycopg2-binary==2.8.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="django-tarantool",
-    version="0.0.17",
+    version="0.0.18",
     package_dir={"django-tarantool": os.path.join("django_tarantool")},
     author="Artem Morozov",
     author_email="artembo@me.com",
@@ -22,4 +22,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    install_requires=[
+        'tarantool>=0.7.1',
+    ],
 )


### PR DESCRIPTION
- add tarantool to testing requirements
- fix sql flush for django 3.1 compatibility
- update readme, remove tarantool package installation section
- remove tarantool from travis-ci
- add CONN_MAX_AGE to the test application settings.py